### PR TITLE
Disable power fbc build

### DIFF
--- a/.tekton/security-profiles-operator-fbc-4-12-pull-request.yaml
+++ b/.tekton/security-profiles-operator-fbc-4-12-pull-request.yaml
@@ -29,7 +29,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/ppc64le
   - name: dockerfile
     value: catalog/v4.12/Containerfile
   - name: path-context

--- a/.tekton/security-profiles-operator-fbc-4-12-push.yaml
+++ b/.tekton/security-profiles-operator-fbc-4-12-push.yaml
@@ -26,7 +26,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/ppc64le
   - name: dockerfile
     value: catalog/v4.12/Containerfile
   - name: path-context

--- a/.tekton/security-profiles-operator-fbc-4-13-pull-request.yaml
+++ b/.tekton/security-profiles-operator-fbc-4-13-pull-request.yaml
@@ -29,7 +29,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/ppc64le
   - name: dockerfile
     value: catalog/v4.13/Containerfile
   - name: path-context

--- a/.tekton/security-profiles-operator-fbc-4-13-push.yaml
+++ b/.tekton/security-profiles-operator-fbc-4-13-push.yaml
@@ -26,7 +26,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/ppc64le
   - name: dockerfile
     value: catalog/v4.13/Containerfile
   - name: path-context


### PR DESCRIPTION
We need to disable the FBC build for Power build, due to failures on OCP4.12 and OCP4.13.