### PR TITLE
Rename baremetal jobs and add 4.22 integration job

### DIFF
--- a/.tekton/integration-tests/integration-test-scenarios/security-profiles-operator-fbc-4-20-integration-tests.yaml 
+++ b/.tekton/integration-tests/integration-test-scenarios/security-profiles-operator-fbc-4-20-integration-tests.yaml 
@@ -16,7 +16,7 @@ spec:
     - name: gangway_api_url
       value: https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com
     - name: ocp_ci_job_name
-      value: periodic-ci-openshift-openshift-tests-private-release-4.20-amd64-nightly-baremetalds-ipi-ovn-lvms-f14-security-profiles
+      value: periodic-ci-openshift-openshift-tests-private-release-4.20-amd64-nightly-metal-ds-ipi-ovn-lvms-f14-security-profiles
     - name: index_image
       value: MULTISTAGE_PARAM_OVERRIDE_INDEX_IMAGE
   resolverRef:

--- a/.tekton/integration-tests/integration-test-scenarios/security-profiles-operator-fbc-4-21-integration-tests.yaml 
+++ b/.tekton/integration-tests/integration-test-scenarios/security-profiles-operator-fbc-4-21-integration-tests.yaml 
@@ -16,7 +16,7 @@ spec:
     - name: gangway_api_url
       value: https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com
     - name: ocp_ci_job_name
-      value: periodic-ci-openshift-openshift-tests-private-release-4.21-amd64-nightly-baremetalds-ipi-ovn-lvms-f14-security-profiles
+      value: periodic-ci-openshift-openshift-tests-private-release-4.21-amd64-nightly-metal-ds-ipi-ovn-lvms-f28-security-profiles
     - name: index_image
       value: MULTISTAGE_PARAM_OVERRIDE_INDEX_IMAGE
   resolverRef:

--- a/.tekton/integration-tests/integration-test-scenarios/security-profiles-operator-fbc-4-22-integration-tests.yaml
+++ b/.tekton/integration-tests/integration-test-scenarios/security-profiles-operator-fbc-4-22-integration-tests.yaml
@@ -4,19 +4,19 @@ kind: IntegrationTestScenario
 metadata:
   annotations:
     test.appstudio.openshift.io/optional: "true"
-  name: security-profiles-operator-fbc-v4-19-e2e-tests
+  name: security-profiles-operator-fbc-v4-22-e2e-tests
   namespace: ocp-isc-tenant
 spec:
-  application: security-profiles-operator-fbc-4-19
+  application: security-profiles-operator-fbc-4-22
   contexts:
-  - description: execute the integration test when component security-profiles-operator-fbc-4-19 updates
+  - description: execute the integration test when component security-profiles-operator-fbc-4-22 updates
       state
-    name: component_security-profiles-operator-fbc-4-19
+    name: component_security-profiles-operator-fbc-4-22
   params:
     - name: gangway_api_url
       value: https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com
     - name: ocp_ci_job_name
-      value: periodic-ci-openshift-openshift-tests-private-release-4.19-amd64-nightly-metal-ipi-ovn-ipv4-f28-security-profiles
+      value: periodic-ci-openshift-openshift-tests-private-release-4.22-amd64-nightly-metal-ds-ipi-ovn-lvms-f14-security-profiles
     - name: index_image
       value: MULTISTAGE_PARAM_OVERRIDE_INDEX_IMAGE
   resolverRef:


### PR DESCRIPTION
Purpose of this PR:

1. Update baremetal job names due to the recent name change
2. Add integration test scenario for OCP 4.22
